### PR TITLE
Refactor: Use monitor_index instead of monitor_id

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,27 +41,19 @@ pub struct Cli {
     pub sentry_dsn: String,
 }
 
-pub fn parse_monitor_ids(input: &str) -> Option<Vec<i64>> {
+pub fn parse_monitor_indices(input: &str) -> Option<Vec<i64>> {
     if input.to_lowercase() == "all" {
         return None; // None represents all monitors
     }
     
-    // Get the list of all monitors to map indices to actual IDs
-    let instance = libvisdesk::LibVisInstance::new();
-    let (monitors, _, _) = instance.get_visible_area();
-    
-    let mut ids = Vec::new();
+    let mut indices = Vec::new();
     for id_str in input.split(',') {
-        if let Ok(index) = id_str.trim().parse::<usize>() {
-            // Convert index to actual monitor ID
-            if index < monitors.len() {
-                ids.push(monitors[index].monitor_id);
-            } else {
-                // Log a warning if index is out of bounds
-                warn!("Monitor index {} is out of bounds, ignoring", index);
-            }
+        if let Ok(index) = id_str.trim().parse::<i64>() {
+            indices.push(index);
+        } else {
+            warn!("Invalid monitor index '{}', ignoring", id_str);
         }
     }
     
-    Some(ids)
+    Some(indices)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use tracing_subscriber::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
-use cli::{Cli, parse_monitor_ids};
+use cli::{Cli, parse_monitor_indices};
 use monitor::VisibilityMonitor;
 use wallpaper::WallpaperController;
 
@@ -79,7 +79,7 @@ async fn main() {
     }
     
     // Parse monitor IDs
-    let monitor_ids = parse_monitor_ids(&cli.monitors);
+    let monitor_indices = parse_monitor_indices(&cli.monitors);
     
     // Create the wallpaper controller with the 64-bit flag
     let controller = WallpaperController::new(cli.wallpaper_engine_path, cli.bit64);
@@ -89,7 +89,7 @@ async fn main() {
         controller,
         cli.per_monitor,
         cli.threshold,
-        monitor_ids,
+        monitor_indices,
     );
     
     if monitor.start_monitoring(cli.update_rate).await {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -16,7 +16,7 @@ pub struct VisibilityMonitor {
     controller: Arc<Mutex<WallpaperController>>,
     per_monitor: bool,
     threshold: u8,
-    monitor_ids: Option<Vec<i64>>,
+    monitor_indices: Option<Vec<i64>>,
     tx: Option<mpsc::Sender<MonitorMessage>>,
     running: bool,
 }
@@ -26,14 +26,14 @@ impl VisibilityMonitor {
         controller: WallpaperController,
         per_monitor: bool,
         threshold: u8,
-        monitor_ids: Option<Vec<i64>>,
+        monitor_indices: Option<Vec<i64>>,
     ) -> Self {
         Self {
             instance: LibVisInstance::new(),
             controller: Arc::new(Mutex::new(controller)),
             per_monitor,
             threshold,
-            monitor_ids,
+            monitor_indices,
             tx: None,
             running: false,
         }
@@ -58,7 +58,7 @@ impl VisibilityMonitor {
         let controller = Arc::clone(&self.controller);
         let per_monitor = self.per_monitor;
         let threshold = self.threshold;
-        let monitor_ids = self.monitor_ids.clone();
+        let monitor_indices = self.monitor_indices.clone();
 
         tokio::spawn(async move {
             Self::process_visibility_updates(
@@ -72,10 +72,10 @@ impl VisibilityMonitor {
         // Set up the callback to forward messages to our channel
         let tx_clone = self.tx.clone().unwrap();
         let callback = move |monitors: &[MonitorVisibleInfo], _total_visible: i64, _total_area: i64, _: *mut std::ffi::c_void| {
-            // Filter monitors if specific IDs were provided
-            let filtered_monitors = if let Some(ids) = &monitor_ids {
+            // Filter monitors if specific indices were provided
+            let filtered_monitors = if let Some(indices) = &monitor_indices {
                 monitors.iter()
-                    .filter(|m| ids.contains(&m.monitor_id))
+                    .filter(|m| indices.contains(&m.monitor_index))
                     .cloned()
                     .collect::<Vec<_>>()
             } else {
@@ -168,10 +168,10 @@ impl VisibilityMonitor {
                                 0
                             };
                             
-                            debug!("Monitor {} visibility: {}%", monitor.monitor_id, visibility_percent);
+                            debug!("Monitor IDX {} visibility: {}%", monitor.monitor_index, visibility_percent);
                             
                             // Get previous visibility for this monitor
-                            let previous_visibility = previous_monitor_visibilities.get(&monitor.monitor_id).cloned();
+                            let previous_visibility = previous_monitor_visibilities.get(&monitor.monitor_index).cloned();
                             
                             // Check if we crossed the threshold in either direction
                             let crossed_threshold_down = visibility_percent < threshold && 
@@ -180,16 +180,16 @@ impl VisibilityMonitor {
                                 (previous_visibility.is_none() || previous_visibility.unwrap() < threshold);
                             
                             // Update previous visibility for this monitor
-                            previous_monitor_visibilities.insert(monitor.monitor_id, visibility_percent);
+                            previous_monitor_visibilities.insert(monitor.monitor_index, visibility_percent);
                             
-                            if crossed_threshold_down && controller_lock.is_playing(Some(monitor.monitor_id)) {
-                                info!("Monitor {} visibility below threshold ({}%), pausing", 
-                                      monitor.monitor_id, threshold);
-                                controller_lock.pause(Some(monitor.monitor_id)).await;
-                            } else if crossed_threshold_up && !controller_lock.is_playing(Some(monitor.monitor_id)) {
-                                info!("Monitor {} visibility above threshold ({}%), resuming", 
-                                      monitor.monitor_id, threshold);
-                                controller_lock.play(Some(monitor.monitor_id)).await;
+                            if crossed_threshold_down && controller_lock.is_playing(Some(monitor.monitor_index)) {
+                                info!("Monitor IDX {} visibility below threshold ({}%), pausing",
+                                      monitor.monitor_index, threshold);
+                                controller_lock.pause(Some(monitor.monitor_index)).await;
+                            } else if crossed_threshold_up && !controller_lock.is_playing(Some(monitor.monitor_index)) {
+                                info!("Monitor IDX {} visibility above threshold ({}%), resuming",
+                                      monitor.monitor_index, threshold);
+                                controller_lock.play(Some(monitor.monitor_index)).await;
                             }
                         }
                     }
@@ -218,8 +218,8 @@ impl VisibilityMonitor {
         // Resume wallpapers before stopping the watcher
         {
             let mut controller = self.get_controller().await;
-            if let Some(ref ids) = self.monitor_ids {
-                for &i in ids.iter() { controller.play(Some(i)).await; }
+            if let Some(ref indices) = self.monitor_indices {
+                for &i in indices.iter() { controller.play(Some(i)).await; }
             } else {
                 controller.play(None).await;
             }

--- a/src/wallpaper.rs
+++ b/src/wallpaper.rs
@@ -1,7 +1,6 @@
 use std::path::Path;
 use std::collections::HashMap;
 use tracing::{info, error, debug};
-use libvisdesk::LibVisInstance;
 
 #[derive(Clone)]
 pub struct WallpaperController {
@@ -9,49 +8,34 @@ pub struct WallpaperController {
     use_64bit: bool,
     global_state: bool, // true = playing, false = paused
     monitor_states: HashMap<i64, bool>,
-    monitor_id_to_index: HashMap<i64, usize>,
 }
 
 impl WallpaperController {
     pub fn new(base_path: String, use_64bit: bool) -> Self {
-        let instance = LibVisInstance::new();
-        let (monitors, _, _) = instance.get_visible_area();
-        
-        let mut monitor_id_to_index = HashMap::new();
-        
-        for (index, monitor) in monitors.iter().enumerate() {
-            monitor_id_to_index.insert(monitor.monitor_id, index);
-        }
-        
         Self {
             executable_path: base_path,
             use_64bit,
             global_state: true, // Assume wallpaper is playing initially
             monitor_states: HashMap::new(),
-            monitor_id_to_index,
         }
     }
 
-    pub async fn pause(&mut self, monitor_id: Option<i64>) -> bool {
-        self.execute_command("pause", monitor_id).await
+    pub async fn pause(&mut self, monitor_index: Option<i64>) -> bool {
+        self.execute_command("pause", monitor_index).await
     }
 
-    pub async fn play(&mut self, monitor_id: Option<i64>) -> bool {
-        self.execute_command("play", monitor_id).await
+    pub async fn play(&mut self, monitor_index: Option<i64>) -> bool {
+        self.execute_command("play", monitor_index).await
     }
 
-    async fn execute_command(&mut self, command: &str, monitor_id: Option<i64>) -> bool {
+    async fn execute_command(&mut self, command: &str, monitor_index: Option<i64>) -> bool {
         let mut args = vec![String::from("-control"), String::from(command)];
         
-        // Add monitor ID if specified
-        if let Some(id) = monitor_id {
-            // Convert system ID to user-friendly index for wallpaper engine
-            let monitor_index = self.monitor_id_to_index.get(&id).cloned().unwrap_or(0);
-            
+        // Add monitor index if specified
+        if let Some(index) = monitor_index {
             args.push(String::from("-monitor"));
-            args.push(monitor_index.to_string());
-            
-            debug!("Using monitor index {} (system ID: {}) for command", monitor_index, id);
+            args.push(index.to_string());
+            debug!("Using monitor index {} for command", index);
         }
         
         // Determine which executable to use based on the 64-bit flag
@@ -88,9 +72,9 @@ impl WallpaperController {
         }).await.unwrap_or(false);
         
         // Update state tracking
-        match monitor_id {
-            Some(id) => {
-                self.monitor_states.insert(id, command == "play");
+        match monitor_index {
+            Some(index) => {
+                self.monitor_states.insert(index, command == "play");
             },
             None => {
                 self.global_state = command == "play";
@@ -100,9 +84,9 @@ impl WallpaperController {
         status
     }
     
-    pub fn is_playing(&self, monitor_id: Option<i64>) -> bool {
-        match monitor_id {
-            Some(id) => *self.monitor_states.get(&id).unwrap_or(&true),
+    pub fn is_playing(&self, monitor_index: Option<i64>) -> bool {
+        match monitor_index {
+            Some(index) => *self.monitor_states.get(&index).unwrap_or(&true),
             None => self.global_state,
         }
     }


### PR DESCRIPTION
This commit refactors the codebase to use `monitor.monitor_index` instead of `monitor_id` for identifying monitors. This change is necessary to align with the latest version of `libvisdesk`, which uses stable monitor indices that match what is shown to you in Windows' Display Settings.

As part of this refactoring, the `monitor_id_to_index` map has been removed from the `WallpaperController`, and all related logic has been updated to use the monitor index directly.